### PR TITLE
Updated node matrix for CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: Merge to Main
 
 # Controls when the action will run. 
 on:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 12, 14, 16 ]
+        node: [ 14, 16, 18 ]
 
     name: Node ${{ matrix.node }} sample
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: PR
+name: Pull Request
 
 # Controls when the action will run. 
 on:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 12, 14, 16 ]
+        node: [ 14, 16, 18 ]
 
     name: Node ${{ matrix.node }} sample
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ npm install -g px-converter
 $ px-converter COMMAND
 running command...
 $ px-converter (-v|--version|version)
-px-converter/0.4.0 darwin-arm64 node-v16.15.0
+px-converter/0.4.1 darwin-arm64 node-v16.15.0
 $ px-converter --help [COMMAND]
 USAGE
   $ px-converter COMMAND
@@ -58,7 +58,7 @@ EXAMPLE
   16px
 ```
 
-_See code: [src/commands/from/pt.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.0/src/commands/from/pt.ts)_
+_See code: [src/commands/from/pt.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.1/src/commands/from/pt.ts)_
 
 ## `px-converter from:rem [REM]`
 
@@ -80,7 +80,7 @@ EXAMPLE
   32px
 ```
 
-_See code: [src/commands/from/rem.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.0/src/commands/from/rem.ts)_
+_See code: [src/commands/from/rem.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.1/src/commands/from/rem.ts)_
 
 ## `px-converter help [COMMAND]`
 
@@ -117,7 +117,7 @@ EXAMPLE
   An object with mass of 0.249Kg from an height of 50 meters, will generate 122.0928 Joules
 ```
 
-_See code: [src/commands/joules.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.0/src/commands/joules.ts)_
+_See code: [src/commands/joules.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.1/src/commands/joules.ts)_
 
 ## `px-converter table:pt`
 
@@ -140,7 +140,7 @@ EXAMPLE
   ...
 ```
 
-_See code: [src/commands/table/pt.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.0/src/commands/table/pt.ts)_
+_See code: [src/commands/table/pt.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.1/src/commands/table/pt.ts)_
 
 ## `px-converter table:rem [BASEPIXEL]`
 
@@ -167,7 +167,7 @@ EXAMPLE
   ...
 ```
 
-_See code: [src/commands/table/rem.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.0/src/commands/table/rem.ts)_
+_See code: [src/commands/table/rem.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.1/src/commands/table/rem.ts)_
 
 ## `px-converter to:pt [PIXEL]`
 
@@ -188,7 +188,7 @@ EXAMPLE
   12pt
 ```
 
-_See code: [src/commands/to/pt.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.0/src/commands/to/pt.ts)_
+_See code: [src/commands/to/pt.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.1/src/commands/to/pt.ts)_
 
 ## `px-converter to:rem [PIXEL]`
 
@@ -210,7 +210,7 @@ EXAMPLE
   1rem
 ```
 
-_See code: [src/commands/to/rem.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.0/src/commands/to/rem.ts)_
+_See code: [src/commands/to/rem.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.1/src/commands/to/rem.ts)_
 
 ## `px-converter to:rgb [HEX]`
 
@@ -231,5 +231,5 @@ EXAMPLE
   rgb(255,255,255)
 ```
 
-_See code: [src/commands/to/rgb.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.0/src/commands/to/rgb.ts)_
+_See code: [src/commands/to/rgb.ts](https://github.com/darkmavis1980/px-converter/blob/v0.4.1/src/commands/to/rgb.ts)_
 <!-- commandsstop -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "px-converter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "px-converter",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/command": "^1.8.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-converter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Alessio Michelini",
   "bin": {
     "px-converter": "./bin/run"


### PR DESCRIPTION
Changed node matrix for GitHub actions, now testing Node version 14, 16, and 18, as previously in list version 12 is now deprecated.